### PR TITLE
Update Binder tag in notebook + additional entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore _build in notebooks directory
+notebooks/_build

--- a/notebooks/_config.yml
+++ b/notebooks/_config.yml
@@ -48,7 +48,7 @@ sphinx:
           icon: fab fa-youtube-square
           type: fontawesome
       launch_buttons:
-        binderhub_url: https://mybinder.org
+        binderhub_url: https://binder-staging.2i2c.cloud
         notebook_interface: jupyterlab
       extra_navbar: |
         Theme by <a href="https://projectpythia.org">Project Pythia</a>.<br><br>


### PR DESCRIPTION
1. Updated Binder tag to 2i2c from mybinder in the example-workflow/2mT notebook
2. Add notebooks/_build to .gitignore, in case a developer builds Jupyterbook locally
