### PR TITLE
Move description out of config file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,6 @@ authors:
     affiliation: University at Albany (State University of New York)  # optional
   - name: "HRRR-AWS Cookbook contributors"  # use the 'name' field to acknowledge organizations 
     website: "https://github.com/ProjectPythia/HRRR-AWS-Cookbook/graphs/contributors"
-title: 'HRRR-AWS-Cookbook'
+title: 'HRRR AWS Cookbook'
+abtract: "A cookbook for working with AWS-served HRRR model output data."
+

--- a/_config.yml
+++ b/_config.yml
@@ -4,10 +4,8 @@
 title: HRRR-AWS-Cookbook
 author: the <a href="https://projectpythia.org/">Project Pythia</a> Community
 logo: notebooks/images/logos/pythia_logo-white-rtext.svg
-email: projectpythia@ucar.edu
 copyright: '2022'
 
-description: A cookbook for working with AWS-served HRRR model output data.
 thumbnail: thumbnail.png
 tags:
   domains:


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
- move `description` out of `config.yml` and into the `abstract` field of the `CITATION.cff` file
- other clean up