### PR TITLE
Zarr v3 update

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,6 @@ dependencies:
   - jupyterlab
   - dask
   - metpy
-  - zarr<3
+  - zarr
   - s3fs
   - sphinx-pythia-theme

--- a/notebooks/example-workflows/2mT.ipynb
+++ b/notebooks/example-workflows/2mT.ipynb
@@ -51,19 +51,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "fluid-transfer",
    "metadata": {},
    "outputs": [],
    "source": [
     "import xarray as xr\n",
-    "import s3fs\n",
     "import metpy\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import cartopy.crs as ccrs\n",
     "import cartopy.feature as cfeature\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from importlib.metadata import version"
    ]
   },
   {
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "cc62deb0-cfd2-4720-ab84-2e0bbece8c3a",
    "metadata": {},
    "outputs": [],
@@ -148,9 +148,7 @@
     "var = 'TMP'\n",
     "level = '2m_above_ground'\n",
     "url1 = 's3://hrrrzarr/sfc/' + date + '/' + date + '_' + hour + 'z_anl.zarr/' + level + '/' + var + '/' + level\n",
-    "url2 = 's3://hrrrzarr/sfc/' + date + '/' + date + '_' + hour + 'z_anl.zarr/' + level + '/' + var\n",
-    "print(url1)\n",
-    "print(url2)"
+    "url2 = 's3://hrrrzarr/sfc/' + date + '/' + date + '_' + hour + 'z_anl.zarr/' + level + '/' + var"
    ]
   },
   {
@@ -168,19 +166,34 @@
    "id": "d661c992-5db9-40af-8ad4-fac7b28dad2f",
    "metadata": {},
    "source": [
-    "Create the S3 maps from the S3 object store."
+    "Connect to the S3 object store. With the [release of Zarr version 3](https://zarr.readthedocs.io/en/latest/user-guide/v3_migration.html), the methods to do this have changed from version 2 (see, e.g. Zarr issues [2706](https://github.com/zarr-developers/zarr-python/issues/2706) and [2748](https://github.com/zarr-developers/zarr-python/issues/2748)) . Test which version is installed and use the appropriate methodology."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "530efd16-4779-4ace-9e71-0bbf6119056e",
+   "execution_count": 3,
+   "id": "07b2f3ee-17e3-4bac-9365-ee73651deaf1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "fs = s3fs.S3FileSystem(anon=True)\n",
-    "file1 = s3fs.S3Map(url1, s3=fs)\n",
-    "file2 = s3fs.S3Map(url2, s3=fs)"
+    "package = \"zarr\"\n",
+    "package_version = version(package)\n",
+    "major_version = int(package_version.split(\".\")[0])  # Extract the major version\n",
+    "\n",
+    "if major_version == 3:      \n",
+    "    import zarr\n",
+    "    import fsspec\n",
+    "    # strip leading 's3://' from url\n",
+    "    url1_3 = url1[5:]\n",
+    "    url2_3 = url2[5:]\n",
+    "    fs = fsspec.filesystem(\"s3\", asynchronous=True)\n",
+    "    file1 = zarr.storage.FsspecStore(fs, path=url1_3)\n",
+    "    file2 = zarr.storage.FsspecStore(fs, path=url2_3)\n",
+    "else:\n",
+    "    import s3fs\n",
+    "    fs = s3fs.S3FileSystem(anon=True)\n",
+    "    file1 = s3fs.S3Map(url1, s3=fs)\n",
+    "    file2 = s3fs.S3Map(url2, s3=fs)"
    ]
   },
   {
@@ -193,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "23db3344-cf7e-48c2-b907-039a195dc73d",
    "metadata": {},
    "outputs": [],
@@ -609,7 +622,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/example-workflows/2mT.ipynb
+++ b/notebooks/example-workflows/2mT.ipynb
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "fluid-transfer",
    "metadata": {},
    "outputs": [],
@@ -63,6 +63,7 @@
     "import cartopy.crs as ccrs\n",
     "import cartopy.feature as cfeature\n",
     "import pandas as pd\n",
+    "import s3fs\n",
     "from importlib.metadata import version"
    ]
   },
@@ -138,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "cc62deb0-cfd2-4720-ab84-2e0bbece8c3a",
    "metadata": {},
    "outputs": [],
@@ -171,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "07b2f3ee-17e3-4bac-9365-ee73651deaf1",
    "metadata": {},
    "outputs": [],
@@ -182,16 +183,14 @@
     "\n",
     "if major_version == 3:      \n",
     "    import zarr\n",
-    "    import fsspec\n",
     "    # strip leading 's3://' from url\n",
     "    url1_3 = url1[5:]\n",
     "    url2_3 = url2[5:]\n",
-    "    fs = fsspec.filesystem(\"s3\", asynchronous=True)\n",
+    "    fs = s3fs.S3FileSystem(anon=True, asynchronous=True)\n",
     "    file1 = zarr.storage.FsspecStore(fs, path=url1_3)\n",
     "    file2 = zarr.storage.FsspecStore(fs, path=url2_3)\n",
     "else:\n",
-    "    import s3fs\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
+    "    fs = s3fs.S3FileSystem(anon=True, asynchronous=False)\n",
     "    file1 = s3fs.S3Map(url1, s3=fs)\n",
     "    file2 = s3fs.S3Map(url2, s3=fs)"
    ]
@@ -206,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "23db3344-cf7e-48c2-b907-039a195dc73d",
    "metadata": {},
    "outputs": [],
@@ -608,9 +607,9 @@
    "allow_errors": false
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 Jan. 2025 Environment",
    "language": "python",
-   "name": "python3"
+   "name": "jan25"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This now supports Zarr v3, while also still supporting v2 via a different workflow. See zarr-developers/zarr-python#2706 and zarr-developers/zarr-python#2748 for context.